### PR TITLE
Fix Install Instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,13 @@
 # DashTrack
 
-Run the following command (for dev):
+### For Developers
+Run the following commands to get access to the DEV environment variables.
+```
+export DT_HOME=$(pwd)
+```
 
+Run the following commands to install the nessasary brew packages.
 ```
 brew install wget
+brew install rm-improved
 ```


### PR DESCRIPTION
Adds missing instructions required to get the code running for a developer in `start.sh`.