### PR TITLE
Fix Missing Infra Cache Removal in Clean Script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,5 +24,5 @@ dependencies
 *.preview
 *.code-workspace
 
-infra/artifacts
-infra/build/formula/out
+**/infra/artifacts
+**/infra/build/formula/out

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # DashTrack
 
-## Installation (WIP)
-&#x26a0;&#xfe0f; In its current iteration, this method will not work. We are still in the process of setting up a reliable deployment target.
+## Installation (&#x26a0;&#xfe0f; WIP)
+
+In its current iteration, this method will not work. We are still in the process of setting up a reliable distribution target.
 
 ```
 brew tap KartavyaSharma/DashTrack-Homebrew

--- a/start.sh
+++ b/start.sh
@@ -176,8 +176,8 @@ EOF
 
 clean() {
     echo "Cleaning up..."
-    echo -e "Removing .cache\nRemoving logs"
-    rip $DT_HOME/.cache $DT_HOME/bkp/logs 2>/dev/null
+    echo -e "Removing .cache\nRemoving logs\nRemoving temp infra files"
+    rip $DT_HOME/.cache $DT_HOME/bkp/logs $DT_HOME/infra/artifacts $DT_HOME/infra/build/formula/out 2>/dev/null
     echo "Removing preview files..."
     # Check if there are any preview files
     preview_files=$(find $DT_HOME -type f -name "*.preview" -print)

--- a/start.sh
+++ b/start.sh
@@ -283,7 +283,7 @@ if [[ "$arch" == "Linux" ]]; then
             sudo apt -y install google-chrome-stable
             chrome_ver=$(google-chrome --version)
         else
-            quit "Google Chrome was not installed. Please install Google Chrome manually to use autofill."
+            quit "Google Chrome was not installed. Please install Google Chrome manually."
         fi
     else
         export DT_CHROME_VER=$chrome_ver
@@ -300,20 +300,20 @@ elif [[ "$arch" == "Darwin" ]]; then
             brew install --cask google-chrome
             chrome_ver=$(/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome --version)
         else
-            cecho -c yellow -t "Google Chrome was not installed. Please install Google Chrome manually to use autofill."
+            cecho -c yellow -t "Google Chrome was not installed. Please install Google Chrome manually."
         fi
     else
         export DT_CHROME_VER=$chrome_ver
         cecho -c green -t "Google Chrome found!"
     fi
 else
-    quit "Invalid architecture: $arch. trapp is only supported on x86_64 and arm64 versions of Darwin and Linux."
+    quit "Invalid architecture: $arch. DashTrack is only supported on x86_64 and arm64 versions of Darwin and Linux."
 fi
 
 # Check post-install
 if [[ "$chrome_ver" == "" ]]; then
     # Ask user to install Google Chrome
-    cecho -c yellow -t "Google Chrome was not installed. Please install Google Chrome manually to use autofill."
+    cecho -c yellow -t "Google Chrome was not installed. Please install Google Chrome manually."
 else
     export DT_CHROME_VER=$chrome_ver
 fi

--- a/start.sh
+++ b/start.sh
@@ -16,6 +16,17 @@ tildify() {
     fi
 }
 
+# If the --dev flag is passed, check if $DT_HOME is set, if it is not, set it to the current directory
+if [[ "$1" == "--dev" ]]; then
+    if [[ ! -d "src" ]]; then
+        echo "Please run this script from the root directory of the project."
+        exit 1
+    fi
+    if [[ "$DT_HOME" == "" ]]; then
+        export DT_HOME=$(pwd)
+    fi
+fi
+
 # Check if the $DT_HOME environment variable is set. Thanks to Bun.sh for this snippet.
 if [[ ! "$1" == "--dev" ]] && [[ "$DT_HOME" == "" || ! "$DT_HOME" =~ "libexec" ]]; then
 # if [[ "$DT_HOME" == "" ]]; then


### PR DESCRIPTION
Removes the `infra/artifact` folder when running with the `--clean` flag.